### PR TITLE
implement predicates for rtype builtins

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Here's the [Rtype signature](https://github.com/ericelliott/rtype#rtype) for the
 
 Roadmap:
 * [x] Predicate function support
-* [ ] Add rtype builtins
+* [x] Add rtype builtins
 * [ ] Add rtype string support
 
 See also: proposals in [rfx future](https://github.com/ericelliott/rfx/blob/master/doc/future.md).
@@ -84,15 +84,15 @@ npm install --save rfx
 ```
 
 ```js
-import rfx from 'rfx';
+import rfx, { isArray, isString } from 'rfx';
 
 export const myFunction = (param, otherParam, options) => {
   /* (Just business logic.) */
 }
 
 const type = (param, otherParam, options) => (
-  typeof param === 'string' &&
-  otherParam instanceof Array &&
+  isString(param) &&
+  isArray(otherParam) &&
   /* ... (Type checking optional and neatly separated!) */
 );
 

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
   },
   "dependencies": {
     "core-js": "^1.2.6",
+    "is": "3.1.0",
     "stamp-utils": "^1.2.4"
   }
 }

--- a/source/index.js
+++ b/source/index.js
@@ -59,4 +59,6 @@ const rfx = (options = {}) => {
   }, options.fn, options);
 };
 
+export * from './predicates';
+
 export default rfx;

--- a/source/predicates.js
+++ b/source/predicates.js
@@ -1,0 +1,35 @@
+import is from 'is';
+
+// isVoid
+
+export function isAny () {
+  return true;
+}
+
+export function isArray (...args) {
+  return !!args.length && args.every((x) => is.array(x));
+}
+
+export function isBoolean (...args) {
+  return !!args.length && args.every((x) => is.bool(x));
+}
+
+export function isFunction (...args) {
+  return !!args.length && args.every((x) => is.fn(x));
+}
+
+export function isNumber (...args) {
+  return !!args.length && args.every((x) => is.number(x));
+}
+
+export function isObject (...args) {
+  return !!args.length && args.every((x) => is.object(x));
+}
+
+export function isString (...args) {
+  return !!args.length && args.every((x) => is.string(x));
+}
+
+export function isVoid (...args) {
+  return args.every((x) => is.undef(x));
+}

--- a/test/flow-logic/index.js
+++ b/test/flow-logic/index.js
@@ -1,6 +1,6 @@
 import test from 'tape';
 
-import rfx from '../../source/index';
+import rfx, { isBoolean, isString } from '../../source/index';
 
 test('rfx', nest => {
   nest.test('...predicate rtype, dev env, onError & invalid args', assert => {
@@ -12,7 +12,7 @@ test('rfx', nest => {
       type (input) {
         assert.pass('should type check');
 
-        return typeof input === 'boolean';
+        return isBoolean(input);
       },
       fn () {
         assert.pass('should call fn');
@@ -48,7 +48,7 @@ test('rfx', nest => {
     const type = Object.assign(
       (a) => {
         assert.pass('should type check');
-        return typeof a === 'string';
+        return isString(a);
       },
       { signature }
     );
@@ -98,7 +98,7 @@ test('rfx', nest => {
       type (input) {
         assert.fail('should not type check');
 
-        return typeof input === 'boolean';
+        return isBoolean(input);
       },
       fn () {
         assert.pass('should call fn');

--- a/test/index.js
+++ b/test/index.js
@@ -1,2 +1,3 @@
 import './flow-logic';
 import './composition';
+import './predicates';

--- a/test/predicates/index.js
+++ b/test/predicates/index.js
@@ -1,0 +1,46 @@
+import test from 'tape';
+
+import {
+  isAny, isArray, isBoolean, isFunction, isNumber, isObject, isString, isVoid
+} from '../../source/index';
+
+test('isAny', t => {
+  t.ok(isAny(), 'permissively accepts no arguments');
+  t.ok(isAny('abc'), 'accepts a string value');
+  t.ok(isAny(undefined, 'abc'), 'accepts multiple values');
+
+  t.end();
+});
+
+[
+  { type: 'Array', fn: isArray, example: ['abc'], nonExample: 1 },
+  { type: 'Boolean', fn: isBoolean, example: true, nonExample: 1 },
+  { type: 'Function', fn: isFunction, example: () => {}, nonExample: 1 },
+  { type: 'Number', fn: isNumber, example: 1, nonExample: true },
+  { type: 'Object', fn: isObject, example: {}, nonExample: 1 },
+  { type: 'String', fn: isString, example: 'abc', nonExample: 1 }
+].forEach(({ type, fn, example, nonExample }) => {
+
+  test(fn.name, t => {
+    t.ok(fn(example), `accepts an ${type} value`);
+    t.ok(fn(example, example), `accepts multiple ${type} values`);
+
+    t.notOk(fn(), 'rejects lack of arguments');
+    t.notOk(fn(nonExample), `rejects non-${type} value`);
+    t.notOk(fn(example, nonExample), `rejects at least one non-${type} value`);
+
+    t.end();
+  });
+
+});
+
+test('isVoid', t => {
+  t.ok(isVoid(), 'accepts no arguments');
+  t.ok(isVoid(undefined), 'accepts an undefined value');
+  t.ok(isVoid(undefined, undefined), 'accepts multiple undefined values');
+
+  t.notOk(isVoid('abc'), `rejects non-undefined value`);
+  t.notOk(isVoid(undefined, 'abc'), `rejects at least one non-undefined value`);
+
+  t.end();
+});


### PR DESCRIPTION
- implemented isAny, isArray, isBoolean, isFunction, isNumber, isObject, isString and isVoid as discussed in #16 
  - these pass through to functions in the [is](https://github.com/enricomarino/is) module
  - for convenience, I exported these in the main "rfx" module, but we could make it "rfx.types" or something instead if you like
  - `isAny()` is currently true even if it has no arguments, should I make this require arguments like all the rest? should `isAny(undefined)` return `true`, or should Any not include Void?
- modified existing example and predicate tests to use these built-in predicates
